### PR TITLE
[Feat] 사용자 정보 업데이트, 정보 확인, 로그인 기능 구현

### DIFF
--- a/src/main/generated/com/wanted/restaurant/boundedContext/restaurant/entity/QRestaurant.java
+++ b/src/main/generated/com/wanted/restaurant/boundedContext/restaurant/entity/QRestaurant.java
@@ -1,0 +1,87 @@
+package com.wanted.restaurant.boundedContext.restaurant.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QRestaurant is a Querydsl query type for Restaurant
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRestaurant extends EntityPathBase<Restaurant> {
+
+    private static final long serialVersionUID = 20076340L;
+
+    public static final QRestaurant restaurant = new QRestaurant("restaurant");
+
+    public final StringPath businessClassificationDivisionName = createString("businessClassificationDivisionName");
+
+    public final StringPath businessPlaceName = createString("businessPlaceName");
+
+    public final StringPath businessPlaceNameAndAddress = createString("businessPlaceNameAndAddress");
+
+    public final NumberPath<Integer> businessStatus = createNumber("businessStatus", Integer.class);
+
+    public final DatePath<java.time.LocalDate> closeBusinessDate = createDate("closeBusinessDate", java.time.LocalDate.class);
+
+    public final NumberPath<Integer> femaleEmployeeCount = createNumber("femaleEmployeeCount", Integer.class);
+
+    public final NumberPath<Double> grade = createNumber("grade", Double.class);
+
+    public final StringPath grandDivisionName = createString("grandDivisionName");
+
+    public final StringPath grandFacilityDivisionName = createString("grandFacilityDivisionName");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DatePath<java.time.LocalDate> licenseBusinessDate = createDate("licenseBusinessDate", java.time.LocalDate.class);
+
+    public final NumberPath<Double> locationPlaceArea = createNumber("locationPlaceArea", Double.class);
+
+    public final NumberPath<Integer> maleEmployeeCount = createNumber("maleEmployeeCount", Integer.class);
+
+    public final StringPath multiUseBusiness = createString("multiUseBusiness");
+
+    public final StringPath refinedLocationAddress = createString("refinedLocationAddress");
+
+    public final StringPath refinedLocationZipCode = createString("refinedLocationZipCode");
+
+    public final StringPath refinedRoadNameAddress = createString("refinedRoadNameAddress");
+
+    public final NumberPath<Double> refinedWGS84Latitude = createNumber("refinedWGS84Latitude", Double.class);
+
+    public final NumberPath<Double> refinedWGS84Longitude = createNumber("refinedWGS84Longitude", Double.class);
+
+    public final StringPath sanitationBusinessName = createString("sanitationBusinessName");
+
+    public final StringPath sanitationIndustryTypeName = createString("sanitationIndustryTypeName");
+
+    public final StringPath sigunCode = createString("sigunCode");
+
+    public final StringPath sigunName = createString("sigunName");
+
+    public final NumberPath<Integer> totalEmployeesCount = createNumber("totalEmployeesCount", Integer.class);
+
+    public final NumberPath<Double> totalFacilityScale = createNumber("totalFacilityScale", Double.class);
+
+    public final NumberPath<Integer> year = createNumber("year", Integer.class);
+
+    public QRestaurant(String variable) {
+        super(Restaurant.class, forVariable(variable));
+    }
+
+    public QRestaurant(Path<? extends Restaurant> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QRestaurant(PathMetadata metadata) {
+        super(Restaurant.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/wanted/restaurant/boundedContext/sigungu/entity/QSigungu.java
+++ b/src/main/generated/com/wanted/restaurant/boundedContext/sigungu/entity/QSigungu.java
@@ -1,0 +1,45 @@
+package com.wanted.restaurant.boundedContext.sigungu.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QSigungu is a Querydsl query type for Sigungu
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSigungu extends EntityPathBase<Sigungu> {
+
+    private static final long serialVersionUID = 1726771360L;
+
+    public static final QSigungu sigungu1 = new QSigungu("sigungu1");
+
+    public final StringPath dosi = createString("dosi");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
+    public final StringPath sigungu = createString("sigungu");
+
+    public QSigungu(String variable) {
+        super(Sigungu.class, forVariable(variable));
+    }
+
+    public QSigungu(Path<? extends Sigungu> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QSigungu(PathMetadata metadata) {
+        super(Sigungu.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/wanted/restaurant/base/config/MvcConfig.java
+++ b/src/main/java/com/wanted/restaurant/base/config/MvcConfig.java
@@ -1,0 +1,29 @@
+package com.wanted.restaurant.base.config;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.wanted.restaurant.base.interceptor.AuthorizationInterceptor;
+import com.wanted.restaurant.base.resolver.LoginUserResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MvcConfig implements WebMvcConfigurer {
+  private final AuthorizationInterceptor authorizationInterceptor;
+  private final LoginUserResolver loginUserResolver;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry){
+    registry.addInterceptor(authorizationInterceptor).excludePathPatterns("/member/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html");
+  }
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(loginUserResolver);
+  }
+}

--- a/src/main/java/com/wanted/restaurant/base/config/MvcConfig.java
+++ b/src/main/java/com/wanted/restaurant/base/config/MvcConfig.java
@@ -20,7 +20,7 @@ public class MvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry){
-    registry.addInterceptor(authorizationInterceptor).excludePathPatterns("/member/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html");
+    registry.addInterceptor(authorizationInterceptor).excludePathPatterns("/member/signup","/member/signin", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html");
   }
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/java/com/wanted/restaurant/base/config/SwaggerConfig.java
+++ b/src/main/java/com/wanted/restaurant/base/config/SwaggerConfig.java
@@ -3,7 +3,9 @@ package com.wanted.restaurant.base.config;
 import org.springframework.context.annotation.Configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 
 @OpenAPIDefinition(
         info = @Info(title = "restaurant",
@@ -11,5 +13,11 @@ import io.swagger.v3.oas.annotations.info.Info;
                 version = "v1")
 )
 @Configuration
+@SecurityScheme(
+	name = "bearerAuth",
+	type = SecuritySchemeType.HTTP,
+	bearerFormat = "JWT",
+	scheme = "bearer"
+)
 public class SwaggerConfig {
 }

--- a/src/main/java/com/wanted/restaurant/base/exceptionHandler/ApiGlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/restaurant/base/exceptionHandler/ApiGlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.wanted.restaurant.base.exceptionHandler;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.stream.Collectors;
+
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.wanted.restaurant.base.rsData.RsData;
+
+@RestControllerAdvice(annotations = {RestController.class}) // 모든 @RestController 에서 발생한 예외에 대한 제어권을 가로챈다.
+public class ApiGlobalExceptionHandler {
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	@ResponseStatus(NOT_FOUND)
+	public RsData<String> errorHandler(MethodArgumentNotValidException exception) {
+		String msg = exception
+			.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.collect(Collectors.joining("/"));
+
+		String data = exception
+			.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getCode)
+			.collect(Collectors.joining("/"));
+
+		return RsData.of("F-MethodArgumentNotValidException", msg, data);
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	@ResponseStatus(INTERNAL_SERVER_ERROR)
+	public RsData<String> errorHandler(RuntimeException exception) {
+		String msg = exception.getClass().toString();
+
+		String data = exception.getMessage();
+
+		return RsData.of("F-RuntimeException", msg, data);
+	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	@ResponseStatus(UNAUTHORIZED) // 예외에 따른 HTTP 상태 코드 설정
+	public RsData<String> handleAuthenticationException(AuthenticationException exception) {
+		String msg = exception.getMessage(); // 예외 메시지 추출
+
+		// RsData.of 메서드 호출
+		return RsData.of("F-AuthenticationException", msg);
+	}
+}

--- a/src/main/java/com/wanted/restaurant/base/exceptionHandler/AuthenticationException.java
+++ b/src/main/java/com/wanted/restaurant/base/exceptionHandler/AuthenticationException.java
@@ -1,0 +1,7 @@
+package com.wanted.restaurant.base.exceptionHandler;
+
+public class AuthenticationException extends RuntimeException {
+	public AuthenticationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/wanted/restaurant/base/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/wanted/restaurant/base/interceptor/AuthorizationInterceptor.java
@@ -1,0 +1,74 @@
+package com.wanted.restaurant.base.interceptor;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.wanted.restaurant.base.exceptionHandler.AuthenticationException;
+import com.wanted.restaurant.base.jwt.JwtProvider;
+import com.wanted.restaurant.base.resolver.LoginMemberContext;
+import com.wanted.restaurant.boundedContext.member.entity.Member;
+import com.wanted.restaurant.boundedContext.member.repository.MemberRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthorizationInterceptor implements HandlerInterceptor {
+	private final JwtProvider jwtProvider;
+	private final MemberRepository memberRepository;
+	private final LoginMemberContext loginMemberContext;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
+		Exception {
+		String token = extractToken(request);
+		if (token == null)
+			throw new AuthenticationException("JWT를 요청 헤더에 넣어주세요");
+		token = token.substring("Bearer ".length());
+		if (!jwtProvider.verify(token))
+			throw new AuthenticationException("유효하지 않은 토큰입니다.");
+		Optional<Member> memberOptional = extractMember(token);
+		if (memberOptional.isEmpty())
+			throw new AuthenticationException("존재하지 않는 사용자입니다.");
+		if (!verifyAccessToken(token, memberOptional))
+			throw new AuthenticationException("저장된 토큰 정보가 유효하지 않습니다.");
+		//사용자 정보 context 등록
+		registerLoginMemberContext(memberOptional);
+		return HandlerInterceptor.super.preHandle(request, response, handler);
+	}
+
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+		Exception ex) throws Exception {
+		releaseLoginMemberContext();
+		HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+	}
+
+	private String extractToken(HttpServletRequest request) {
+		return request.getHeader("Authorization");
+	}
+
+	private Optional<Member> extractMember(String token) {
+		return memberRepository.findById(Long.valueOf((Integer)jwtProvider.getClaims(token).get("id")));
+	}
+
+	private boolean verifyAccessToken(String token, Optional<Member> memberOptional) {
+		if (memberOptional.isEmpty())
+			throw new AuthenticationException("존재하지 않는 사용자입니다.");
+		return token.equals(memberOptional.get().getAccessToken());
+	}
+
+	private void registerLoginMemberContext(Optional<Member> memberOptional) {
+		if (memberOptional.isEmpty())
+			return;
+		loginMemberContext.save(memberOptional.get());
+	}
+
+	private void releaseLoginMemberContext() {
+		loginMemberContext.remove();
+	}
+}

--- a/src/main/java/com/wanted/restaurant/base/interceptor/AuthorizationTestController.java
+++ b/src/main/java/com/wanted/restaurant/base/interceptor/AuthorizationTestController.java
@@ -1,0 +1,17 @@
+package com.wanted.restaurant.base.interceptor;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.wanted.restaurant.base.resolver.LoginMember;
+import com.wanted.restaurant.base.resolver.LoginUser;
+
+@RestController
+@RequestMapping("/v1/authorization/test")
+public class AuthorizationTestController {
+  @GetMapping
+  public String authorizationTest(@LoginUser LoginMember loginMember){
+    return loginMember.getAccount();
+  }
+}

--- a/src/main/java/com/wanted/restaurant/base/resolver/LoginMember.java
+++ b/src/main/java/com/wanted/restaurant/base/resolver/LoginMember.java
@@ -1,0 +1,16 @@
+package com.wanted.restaurant.base.resolver;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import com.wanted.restaurant.boundedContext.member.entity.Member;
+@Getter
+@AllArgsConstructor
+public class LoginMember {
+  private Long id;
+  private String account;
+  private String accessToken;
+  public static LoginMember of(Member member){
+    return new LoginMember(member.getId(),member.getAccount(),member.getAccessToken());
+  }
+}

--- a/src/main/java/com/wanted/restaurant/base/resolver/LoginMemberContext.java
+++ b/src/main/java/com/wanted/restaurant/base/resolver/LoginMemberContext.java
@@ -1,0 +1,22 @@
+package com.wanted.restaurant.base.resolver;
+
+import org.springframework.stereotype.Component;
+
+import com.wanted.restaurant.boundedContext.member.entity.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginMemberContext {
+  private final ThreadLocal<LoginMember> loginMemberThreadLocal = new ThreadLocal<>();
+  public void save(Member member){
+    loginMemberThreadLocal.set(LoginMember.of(member));
+  }
+  public LoginMember getLoginMember(){
+    return loginMemberThreadLocal.get();
+  }
+  public void remove(){
+    loginMemberThreadLocal.remove();
+  }
+}

--- a/src/main/java/com/wanted/restaurant/base/resolver/LoginUser.java
+++ b/src/main/java/com/wanted/restaurant/base/resolver/LoginUser.java
@@ -1,0 +1,11 @@
+package com.wanted.restaurant.base.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface LoginUser {
+}

--- a/src/main/java/com/wanted/restaurant/base/resolver/LoginUserResolver.java
+++ b/src/main/java/com/wanted/restaurant/base/resolver/LoginUserResolver.java
@@ -1,0 +1,25 @@
+package com.wanted.restaurant.base.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginUserResolver implements HandlerMethodArgumentResolver {
+  private final LoginMemberContext loginMemberContext;
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.hasParameterAnnotation(LoginUser.class) && parameter.getParameterType().equals(LoginMember.class);
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    return loginMemberContext.getLoginMember();
+  }
+}

--- a/src/main/java/com/wanted/restaurant/boundedContext/initData/NotProd.java
+++ b/src/main/java/com/wanted/restaurant/boundedContext/initData/NotProd.java
@@ -31,6 +31,8 @@ public class NotProd {
 				.account("user1")
 				.password(password)
 				.email("user1@test.com")
+				// 유효기간 : 1년(2023-11-06)
+				.accessToken("eyJhbGciOiJIUzUxMiJ9.eyJib2R5Ijoie1wiaWRcIjoxLFwiYWNjb3VudFwiOlwidXNlcjFcIn0iLCJleHAiOjE3MzA3ODc1NDd9.JFALSiab13HzYvVjrmv5nWG_KAza579-HwifKL_oaO1f6CF7IFJ1kVXrGcKRuM0v1kD4KeTW7KjeMPavmOtOZA")
 				.build();
 
 			Member user2 = Member.builder()

--- a/src/main/java/com/wanted/restaurant/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/wanted/restaurant/boundedContext/member/entity/Member.java
@@ -31,6 +31,7 @@ public class Member {
 	private String password;
 	@Email
 	private String email;
+	@JsonIgnore
 	private String accessToken;
 	private Integer tempCode;
 

--- a/src/main/java/com/wanted/restaurant/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/wanted/restaurant/boundedContext/member/service/MemberService.java
@@ -160,4 +160,11 @@ public class MemberService {
 
 		return RsData.of("S-1", "회원 정보 업데이트 성공", modifyMember);
 	}
+
+	public RsData<Member> get(Long memberId) {
+		Member member = memberRepository.findById(memberId).get();
+		if(member == null)
+			return RsData.of("F-1", "일치하는 회원정보가 없습니다.");
+		return RsData.of("S-1", "회원 조회 성공", member);
+	}
 }

--- a/src/main/java/com/wanted/restaurant/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/wanted/restaurant/boundedContext/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.wanted.restaurant.boundedContext.member.service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -10,8 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.wanted.restaurant.base.jwt.JwtProvider;
 import com.wanted.restaurant.base.rsData.RsData;
 import com.wanted.restaurant.boundedContext.email.service.EmailService;
+import com.wanted.restaurant.boundedContext.member.entity.AlarmType;
 import com.wanted.restaurant.boundedContext.member.entity.Member;
 import com.wanted.restaurant.boundedContext.member.repository.MemberRepository;
+import com.wanted.restaurant.boundedContext.sigungu.service.SigunguService;
 import com.wanted.restaurant.util.Ut;
 
 import at.favre.lib.crypto.bcrypt.BCrypt;
@@ -25,6 +28,8 @@ public class MemberService {
 	private final JwtProvider jwtProvider;
 
 	private final EmailService emailService;
+
+	private final SigunguService sigunguService;
 
 	@Transactional
 	public RsData join(String account, String password, String email) {
@@ -124,5 +129,35 @@ public class MemberService {
 		memberRepository.save(modifiedMember);
 
 		return newAccessToken;
+	}
+
+	@Transactional
+	public RsData update(Long memberId, String doSi, String sgg, String alarm) {
+		Member member = memberRepository.findById(memberId).get();
+
+		// 강원 or 강원도, 세종 or 세종시 or 세종특별시 등 입력 다양하게 할 수 있으니 앞에 2글자만 추출
+		RsData<List<Double>> rsDataLatAndLon = sigunguService.getLatAndLonByDoSiAndSgg(doSi.substring(0, 2), sgg.substring(0, 2));
+
+		if(rsDataLatAndLon.isFail())
+			return rsDataLatAndLon;
+
+		AlarmType alarmType;
+		if(alarm.contains("y") || alarm.contains("Y"))
+			alarmType = AlarmType.YES;
+		else
+			alarmType = AlarmType.NO;
+
+		List<Double> data = rsDataLatAndLon.getData();
+
+
+		Member modifyMember = member.toBuilder()
+			.lon(String.valueOf(data.get(0)))
+			.lat(String.valueOf(data.get(1)))
+			.alarmType(alarmType)
+			.build();
+
+		memberRepository.save(modifyMember);
+
+		return RsData.of("S-1", "회원 정보 업데이트 성공", modifyMember);
 	}
 }

--- a/src/main/java/com/wanted/restaurant/boundedContext/sigungu/repository/SigunguRepository.java
+++ b/src/main/java/com/wanted/restaurant/boundedContext/sigungu/repository/SigunguRepository.java
@@ -4,4 +4,5 @@ import com.wanted.restaurant.boundedContext.sigungu.entity.Sigungu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SigunguRepository extends JpaRepository<Sigungu, Long> {
+	Sigungu findByDosiContainingAndSigunguContaining(String doSi, String sgg);
 }

--- a/src/main/java/com/wanted/restaurant/boundedContext/sigungu/service/SigunguService.java
+++ b/src/main/java/com/wanted/restaurant/boundedContext/sigungu/service/SigunguService.java
@@ -3,10 +3,10 @@ package com.wanted.restaurant.boundedContext.sigungu.service;
 import com.wanted.restaurant.base.rsData.RsData;
 import com.wanted.restaurant.boundedContext.sigungu.entity.Sigungu;
 import com.wanted.restaurant.boundedContext.sigungu.repository.SigunguRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -19,6 +19,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SigunguService {
 
     private final SigunguRepository sigunguRepository;
@@ -63,4 +64,11 @@ public class SigunguService {
         return RsData.of("S-1", "Data insertion complete", sigungusList);
     }
 
+    public RsData<List<Double>> getLatAndLonByDoSiAndSgg(String doSi, String sgg) {
+        Sigungu sigungu = sigunguRepository.findByDosiContainingAndSigunguContaining(doSi, sgg);
+        if(sigungu == null)
+            return RsData.of("F-1", "지역 조회에 실패하였습니다.");
+
+        return RsData.of("S-1", "지역 조회 성공", List.of(sigungu.getLongitude(), sigungu.getLatitude()));
+    }
 }

--- a/src/test/java/com/wanted/restaurant/boundedContext/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/wanted/restaurant/boundedContext/member/controller/MemberControllerTests.java
@@ -124,7 +124,7 @@ public class MemberControllerTests {
 				post("/member/signin")
 					.content("""
                     {
-                        "account": "user1",
+                        "account": "user2",
                         "password": "1234"
                     }
                     """.stripIndent())
@@ -150,7 +150,7 @@ public class MemberControllerTests {
 				post("/member/signin")
 					.content("""
                     {
-                        "account": "user1",
+                        "account": "user2",
                         "password": "1234"
                     }
                     """.stripIndent())
@@ -180,7 +180,7 @@ public class MemberControllerTests {
 				post("/member/signin")
 					.content("""
                     {
-                        "account": "user1",
+                        "account": "user2",
                         "password": "1234"
                     }
                     """.stripIndent())

--- a/src/test/java/com/wanted/restaurant/boundedContext/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/wanted/restaurant/boundedContext/member/controller/MemberControllerTests.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.nio.charset.StandardCharsets;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,16 @@ public class MemberControllerTests {
 
 	@Autowired
 	private MemberRepository memberRepository;
+
+	private Member user1;
+	private String user1Token;
+
+	@BeforeEach
+	void init() {
+		// 테스트용 user1 토큰 가져오기
+		user1 = memberRepository.findByAccount("user1").get();
+		user1Token = user1.getAccessToken();
+	}
 
 	@Test
 	@DisplayName("POST /member/signup 은 회원가입을 처리한다.")
@@ -258,5 +269,56 @@ public class MemberControllerTests {
 			.andExpect(jsonPath("$.resultCode").value("F-1"))
 			.andExpect(jsonPath("$.msg").value( "이메일 인증 코드가 일치하지 않습니다."))
 			.andExpect(jsonPath("$.data").isEmpty());
+	}
+
+	@Test
+	@DisplayName("사용자 정보 업데이트 테스트, 알람 설정 기본값 No")
+	void t8() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				patch("/member/update")
+					.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+					.content("""
+                    {
+						"doSi": "강원도",
+						"sgg": "춘천시"
+                    }
+                    """.stripIndent())
+					// JSON 형태로 보내겠다
+					.contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+			)
+			.andDo(print());
+
+		// 춘천 값 확인
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value( "회원 정보 업데이트 성공"))
+			.andExpect(jsonPath("$.data.lon").value("127.7323111"))
+			.andExpect(jsonPath("$.data.lat").value("37.87854167"))
+			.andExpect(jsonPath("$.data.alarmType").value("NO"));
+	}
+
+	@Test
+	@DisplayName("사용자 정보 확인")
+	void t9() throws Exception {
+		// When
+		ResultActions resultActions = mvc
+			.perform(
+				get("/member/me")
+					.header("Authorization", "Bearer " + user1Token) // 헤더에 Authorization 값을 추가
+			)
+			.andDo(print());
+
+		// 춘천 값 확인
+		resultActions
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(jsonPath("$.resultCode").value("S-1"))
+			.andExpect(jsonPath("$.msg").value( "회원 조회 성공"))
+			.andExpect(jsonPath("$.data.memberId").value("1"))
+			.andExpect(jsonPath("$.data.userName").value("user1"))
+			.andExpect(jsonPath("$.data.email").value("user1@test.com"))
+			.andExpect(jsonPath("$.data.alarmType").value("null"));
 	}
 }


### PR DESCRIPTION
## 🌿 PR타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️관련 이슈[#]
close #13 
close #11 
close #10 
### 📑 개요
사용자 정보 조회, 정보 업데이트(위치 정보, 알람 여부), 로그인 기능 SNS Feed Service에서 가져오기
###  🧷 변경사항
<!--변경 내용을 적어주세요 (커밋 번호를 적어주세요)-->
- **src/main/java/com/wanted/restaurant/boundedContext/member/controller/MemberController.java**
  - updateInfo : 사용자 위치 받아서 위도, 경도, 알람 여부 업로드
   - memberInfo : 사용자 정보 리턴, DTO 객체 별도 생성(필드명 다름)

- **src/main/java/com/wanted/restaurant/boundedContext/member/entity/Member.java**
  - 사용자 정보 조회할 때 Token값 안나오게 하기 위함

- **src/main/java/com/wanted/restaurant/boundedContext/sigungu/service/SigunguService.java**
  - Transactional 어노테이션 자크르타꺼 사용하면 readOnly 설정 다르기에 다른 어노테이션 사용
   - findByDosiContainingAndSigunguContaining : 도시와 시군구 Like 함수 '%도시명%', '%시군구명%' 으로 검색하기 위한 Containing 메서드 사용
   - 처음에 Like로 했다가 수정했는데, 아래 블로그 보면 좋을 듯 합니다!
     [Spring Data JPA 쿼리 like, containing의 차이점](https://velog.io/@jehpark/Spring-Data-JPA-%EC%BF%BC%EB%A6%AC-like-containing%EC%9D%98-%EC%B0%A8%EC%9D%B4%EC%A0%90)

- 나머지 인터셉터 등은 SNS Feed Service에서 가져옴

## 📷 스크린샷

## 👀 기타
- 사용자 정보 업데이트 할 때 `"알람여부"`, `"시군구 변경"`, `"시군구 변경 + 알람 여부"` 3개로 만들까 하다가 `"시군구 변경 + 알람 여부"` 하나로 합쳤습니다.
- Redis로 1일 주기로 갱신하면 성능 개선에 좋을 듯 한데 리팩토링으로 남겨두겠습니다.
- 디스코드 웹훅을 공부해보겠습니다..!